### PR TITLE
Remove disabled "devel" block

### DIFF
--- a/Formula/arb.rb
+++ b/Formula/arb.rb
@@ -9,16 +9,16 @@ class Arb < Formula
   #   sha256 "8b1fc3fd11bbb05aca4731ac8803c004a4f2b6b87c11b543660d07ea349a6c21"
   # end
 
-  # ARB production version - called devel in homebrew
-  devel do
+  # ARB production version
+  stable do
     url "http://download.arb-home.de/special/manual-builds/2020_03_03/arb-r18342-source.tgz"
     sha256 "f4e0c888f3af4c5f77049e7670254aa88559a1ca25faefe14caaa9bec6483baf"
     version "6.1-beta_r18342"
   end
 
-  # ARB development version - called HEAD in homebrew
+  # ARB development version
   head do
-    url "http://vc.arb-home.de/readonly/trunk", :using => :svn
+     url "http://vc.arb-home.de/readonly/trunk", :using => :svn
   end
 
   ##############################################################################


### PR DESCRIPTION
The "devel do" block was removed from brew, leading to this error:

```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/arb-project/homebrew-arb/Formula/arb.rb
arb: Calling 'devel' blocks in formulae is disabled! Use 'head' blocks or @-versioned formulae instead.
Please report this issue to the arb-project/arb tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/arb-project/homebrew-arb/Formula/arb.rb:13
```

Out of the three levels of stability (head = trunk, devel = production, stable = release, brew/arb lingo), the "release" is the least important - the most recent stable version is less useful than the most recent production build. Moreover, "production" means "stable". So dropping the "release" version and calling the production versions stable.

Hope this works.