### PR TITLE
Update macos versions in workflows

### DIFF
--- a/.github/workflows/arb-head-tests.yml
+++ b/.github/workflows/arb-head-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
     - name: add tap from current branch
       run: |
         mkdir -p $(dirname $(brew --repo arb-project/arb))
@@ -29,7 +29,7 @@ jobs:
         HOMEBREW_LOGS: ${{github.workspace}}/.homebrew-logs
       run: brew install arb-project/arb/arb --HEAD --with-test-only --keep-tmp
     - name: save Homebrew logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: Homebrew logs

--- a/.github/workflows/arb-head-tests.yml
+++ b/.github/workflows/arb-head-tests.yml
@@ -10,7 +10,7 @@ jobs:
     name: Run tests for head version of ARB
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-15-intel, macos-26-intel]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/arb-head.yml
+++ b/.github/workflows/arb-head.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build head version of ARB
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-15-intel, macos-26-intel]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/arb-head.yml
+++ b/.github/workflows/arb-head.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
     - name: add tap from current branch
       run: |
         mkdir -p $(dirname $(brew --repo arb-project/arb))
@@ -29,7 +29,7 @@ jobs:
         HOMEBREW_LOGS: .homebrew-logs
       run: brew install arb-project/arb/arb --HEAD
     - name: save Homebrew logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure()
       with:
         name: Homebrew logs

--- a/.github/workflows/arb-production.yml
+++ b/.github/workflows/arb-production.yml
@@ -1,9 +1,12 @@
 name: ARB Production
 
+# Current production version does not build on recent macOS versions. Disable workflow.
 on:
   push:
-  schedule:
-    - cron: "0 0 * * 1"
+    branches-ignore:
+      - **
+#  schedule:
+#    - cron: "0 0 * * 1"
 
 jobs:
   build:

--- a/.github/workflows/arb-stable-tests.yml
+++ b/.github/workflows/arb-stable-tests.yml
@@ -1,7 +1,10 @@
 name: ARB stable with tests
 
+# Current stable version does not build on recent macOS versions. Disable workflow.
 on:
   push:
+    branches-ignore:
+      - **
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/arb-stable.yml
+++ b/.github/workflows/arb-stable.yml
@@ -1,7 +1,10 @@
 name: ARB stable
 
+# Current stable version does not build on recent macOS versions. Disable workflow.
 on:
   push:
+    branches-ignore:
+      - **
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/arb7.yml
+++ b/.github/workflows/arb7.yml
@@ -1,7 +1,10 @@
 name: ARB 7
 
+# Current release version does not build on recent macOS versions. Disable workflow.
 on:
   push:
+    branches-ignore:
+      - **
   schedule:
     - cron: "0 0 * * 1"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # homebrew-arb
 
-![ARB 7](https://github.com/arb-project/homebrew-arb/workflows/ARB%207/badge.svg)
-![ARB Production version](https://github.com/arb-project/homebrew-arb/workflows/ARB%20Production/badge.svg)
 ![ARB head version](https://github.com/arb-project/homebrew-arb/workflows/ARB%20head/badge.svg)
 
 Homebrew tap for formulae to build [ARB](http://www.arb-home.de) and related


### PR DESCRIPTION
Update workflows 
- use the macOS-runners currently offered by GitHub for x86 builds
- disable workflows that can't be build on those macOS versions
- remove badges for the disabled workflows